### PR TITLE
Print plain object in development for better visibility.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,16 @@ enum LogLevel {
   ERROR = 'error',
 }
 
+interface Message {
+  timestamp: string
+  log_level: string
+  event: string
+  body: unknown
+  message: {
+    event: string
+  }
+}
+
 /**
  * Creates the message structure.
  *
@@ -18,8 +28,8 @@ function createMessage (
   event: string,
   messageEvent: string,
   logLevel: LogLevel
-): string {
-  return JSON.stringify({
+): string | Message {
+  const data: Message = {
     timestamp: new Date().toISOString(),
     log_level: logLevel,
     event: event,
@@ -27,7 +37,13 @@ function createMessage (
     message: {
       event: messageEvent
     }
-  })
+  }
+
+  if (process.env.NODE_ENV === 'development') {
+    return data
+  }
+
+  return JSON.stringify(data)
 }
 
 /**


### PR DESCRIPTION
Checks if the NODE_ENV is set to development and prints the message as a plain object instead of a stringed version of the message. This helps the developers using this library to better see what is happening on their console.

Print like the following image
![Screenshot 2020-08-31 at 13 02 01](https://user-images.githubusercontent.com/53574590/91713502-2e1eb500-eb8a-11ea-9ef6-3105f1da8846.png)

Instead of this way:

![Screenshot 2020-08-31 at 13 04 07](https://user-images.githubusercontent.com/53574590/91713655-78079b00-eb8a-11ea-8847-7aad42188808.png)

