### PR TITLE
Allow log methods to be used logging only a message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blacklane/kiev-js",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -65,6 +65,15 @@ describe('logger', () => {
       expect(message.environment).toStrictEqual(environment)
       expect(message).toMatchObject(logPayload)
     })
+
+    it('logs only the message without extra params', () => {
+      expect.hasAssertions()
+
+      logger.debug(logMessage)
+      const loggedData = JSON.parse(mockLogLevel.debug.mock.calls[0][0])
+
+      expect(loggedData.message).toStrictEqual(logMessage)
+    })
   })
 
   describe('info', () => {
@@ -87,6 +96,15 @@ describe('logger', () => {
       expect(message.level).toStrictEqual(LogLevel.INFO)
       expect(message.environment).toStrictEqual(environment)
       expect(message).toMatchObject(logPayload)
+    })
+
+    it('logs only the message without extra params', () => {
+      expect.hasAssertions()
+
+      logger.info(logMessage)
+      const loggedData = JSON.parse(mockLogLevel.info.mock.calls[0][0])
+
+      expect(loggedData.message).toStrictEqual(logMessage)
     })
   })
 
@@ -111,6 +129,15 @@ describe('logger', () => {
       expect(message.level).toStrictEqual(LogLevel.WARN)
       expect(message.environment).toStrictEqual(environment)
       expect(message).toMatchObject(logPayload)
+    })
+
+    it('logs only the message without extra params', () => {
+      expect.hasAssertions()
+
+      logger.warn(logMessage)
+      const loggedData = JSON.parse(mockLogLevel.warn.mock.calls[0][0])
+
+      expect(loggedData.message).toStrictEqual(logMessage)
     })
   })
 
@@ -138,6 +165,15 @@ describe('logger', () => {
       expect(message.environment).toStrictEqual(environment)
       expect(message).toMatchObject(logPayload)
     })
+
+    it('logs only the message without extra params', () => {
+      expect.hasAssertions()
+
+      logger.error(logMessage)
+      const loggedData = JSON.parse(mockLogLevel.error.mock.calls[0][0])
+
+      expect(loggedData.message).toStrictEqual(logMessage)
+    })
   })
 
   describe('trace', () => {
@@ -161,6 +197,15 @@ describe('logger', () => {
       expect(message.level).toStrictEqual(LogLevel.TRACE)
       expect(message.environment).toStrictEqual(environment)
       expect(message).toMatchObject(logPayload)
+    })
+
+    it('logs only the message without extra params', () => {
+      expect.hasAssertions()
+
+      logger.trace(logMessage)
+      const loggedData = JSON.parse(mockLogLevel.trace.mock.calls[0][0])
+
+      expect(loggedData.message).toStrictEqual(logMessage)
     })
   })
 })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -7,6 +7,7 @@ const mockLogLevel = logLevel as jest.Mocked<typeof logLevel>
 let logger: Logger
 let applicationName: string
 let environment: string
+let logMessage: string
 
 const logPayload = {
   user: {
@@ -27,6 +28,7 @@ describe('logger', () => {
       'message',
       'timestamp'
     ]
+    logMessage = 'There was an event here, see the payload'
   })
 
   beforeEach(() => {
@@ -51,7 +53,7 @@ describe('logger', () => {
     it('logs when current level is equal or greater than the DEBUG level', () => {
       expect.assertions(6)
 
-      logger.debug('There was an event here, see the payload', logPayload)
+      logger.debug(logMessage, logPayload)
       const message = JSON.parse(mockLogLevel.debug.mock.calls[0][0])
 
       expect(mockLogLevel.debug).toHaveBeenCalledTimes(1)
@@ -74,7 +76,7 @@ describe('logger', () => {
     it('logs when current level is equal or greater than the INFO level', () => {
       expect.assertions(6)
 
-      logger.info('There were an event here, see the payload', logPayload)
+      logger.info(logMessage, logPayload)
       const message = JSON.parse(mockLogLevel.info.mock.calls[0][0])
 
       expect(mockLogLevel.info).toHaveBeenCalledTimes(1)
@@ -97,7 +99,7 @@ describe('logger', () => {
     it('logs when current level is equal or greater than the WARN level', () => {
       expect.assertions(6)
 
-      logger.warn('There were an event here, see the payload', logPayload)
+      logger.warn(logMessage, logPayload)
 
       const message = JSON.parse(mockLogLevel.warn.mock.calls[0][0])
 
@@ -123,7 +125,7 @@ describe('logger', () => {
 
       logger.setLevel(LogLevel.ERROR)
 
-      logger.error('There were an event here, see the payload', logPayload)
+      logger.error(logMessage, logPayload)
 
       const message = JSON.parse(mockLogLevel.error.mock.calls[0][0])
 
@@ -147,7 +149,7 @@ describe('logger', () => {
     it('logs when current level is equal the TRACE level', () => {
       expect.assertions(6)
 
-      logger.trace('There were an event here, see the payload', logPayload)
+      logger.trace(logMessage, logPayload)
 
       const message = JSON.parse(mockLogLevel.trace.mock.calls[0][0])
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,9 +55,9 @@ class Logger {
    * Generates an output log with severity level DEBUG.
    *
    * @param {String} message is the core information detail of your log entry. By reading it anyone should understand what the log entry is about.
-   * @param {object} payload is a JSON object, usually a request or event payload.
+   * @param {object} [payload] is a JSON object, usually a request or event payload.
    */
-  public debug (message: string, payload: Object): void {
+  public debug (message: string, payload: Object = {}): void {
     logger.debug(this._buildPayload(LogLevel.DEBUG, message, payload))
   }
 
@@ -65,9 +65,9 @@ class Logger {
    * Generates an output log with severity level INFO.
    *
    * @param {String} message is the core information detail of your log entry. By reading it anyone should understand what the log entry is about.
-   * @param {object} payload is a JSON object, usually a request or event payload.
+   * @param {object} [payload] is a JSON object, usually a request or event payload.
    */
-  public info (message: string, payload: Object): void {
+  public info (message: string, payload: Object = {}): void {
     logger.info(this._buildPayload(LogLevel.INFO, message, payload))
   }
 
@@ -75,9 +75,9 @@ class Logger {
    * Generates an output log with severity level WARN.
    *
    * @param {String} message is the core information detail of your log entry. By reading it anyone should understand what the log entry is about.
-   * @param {object} payload is a JSON object, usually a request or event payload.
+   * @param {object} [payload] is a JSON object, usually a request or event payload.
    */
-  public warn (message: string, payload: Object): void {
+  public warn (message: string, payload: Object = {}): void {
     logger.warn(this._buildPayload(LogLevel.WARN, message, payload))
   }
 
@@ -85,9 +85,9 @@ class Logger {
    * Generates an output log with severity level ERROR.
    *
    * @param {String} message is the core information detail of your log entry. By reading it anyone should understand what the log entry is about.
-   * @param {object} payload is a JSON object, usually a request or event payload.
+   * @param {object} [payload] is a JSON object, usually a request or event payload.
    */
-  public error (message: string, payload: Object): void {
+  public error (message: string, payload: Object = {}): void {
     logger.error(this._buildPayload(LogLevel.ERROR, message, payload))
   }
 
@@ -95,9 +95,9 @@ class Logger {
    * Generates an output log with severity level TRACE.
    *
    * @param {String} message is the core information detail of your log entry. By reading it anyone should understand what the log entry is about.
-   * @param {object} payload is a JSON object, usually a request or event payload.
+   * @param {object} [payload] is a JSON object, usually a request or event payload.
    */
-  public trace (message: string, payload: Object): void {
+  public trace (message: string, payload: Object = {}): void {
     logger.trace(this._buildPayload(LogLevel.TRACE, message, payload))
   }
 


### PR DESCRIPTION
This PR is for making the logger methods `info`, `warn` & etc to support only the message parameter, for a case like `info` and `debug` where we want to log only a message. Ex:

```javascript
logger.debug('Here goes a message only')
```

* It is backward compatible with the previous version.